### PR TITLE
timestamp removed from TOF digits and other fixes

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/Cluster.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/Cluster.h
@@ -44,16 +44,16 @@ class Cluster : public o2::BaseCluster<float>
 
   Cluster() = default;
 
-  Cluster(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz, float timeRaw, float time, float tot, int L0L1latency, int deltaBC);
+  Cluster(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz, double timeRaw, double time, float tot, int L0L1latency, int deltaBC);
 
   ~Cluster() = default;
 
   void SetBaseData(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz);
 
-  float getTimeRaw() const { return mTimeRaw; }             // Cluster ToF getter
-  void setTimeRaw(float timeRaw) { mTimeRaw = timeRaw; }    // Cluster ToF setter
-  float getTime() const { return mTime; }                   // Cluster ToF getter
-  void setTime(float time) { mTime = time; }                // Cluster ToF setter
+  double getTimeRaw() const { return mTimeRaw; }             // Cluster ToF getter
+  void setTimeRaw(double timeRaw) { mTimeRaw = timeRaw; }    // Cluster ToF setter
+  double getTime() const { return mTime; }                   // Cluster ToF getter
+  void setTime(double time) { mTime = time; }                // Cluster ToF setter
   float getTot() const { return mTot; }                     // Cluster Charge getter
   void setTot(int tot) { mTot = tot; }                      // Cluster ToT setter
   int getL0L1Latency() const { return mL0L1Latency; };      // L0L1 latency
@@ -111,8 +111,8 @@ class Cluster : public o2::BaseCluster<float>
  private:
   friend class boost::serialization::access;
 
-  float mTimeRaw;   // raw TOF time // CZ: in AliRoot it is a double
-  float mTime;      // calibrated TOF time // CZ: in AliRoot it is a double
+  double mTimeRaw;   // raw TOF time // CZ: in AliRoot it is a double
+  double mTime;      // calibrated TOF time // CZ: in AliRoot it is a double
   float mTot;       // Time-Over-threshold // CZ: in AliRoot it is a double
   int mL0L1Latency; // L0L1 latency // CZ: is it different per cluster? Checking one ESD file, it seems that it is always the same (see: /alice/data/2017/LHC17n/000280235/pass1/17000280235019.100/AliESDs.root)
   int mDeltaBC;     // DeltaBC --> can it be a char or short? // CZ: is it different per cluster? Checking one ESD file, it seems that it can vary (see: /alice/data/2017/LHC17n/000280235/pass1/17000280235019.100/AliESDs.root)

--- a/DataFormats/Detectors/TOF/src/Cluster.cxx
+++ b/DataFormats/Detectors/TOF/src/Cluster.cxx
@@ -22,7 +22,7 @@ using namespace o2::tof;
 
 ClassImp(o2::tof::Cluster);
 
-Cluster::Cluster(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz, float timeRaw, float time, float tot, int L0L1Latency, int deltaBC) : o2::BaseCluster<float>(sensid, x, y, z, sy2, sz2, syz), mTimeRaw(timeRaw), mTime(time), mTot(tot), mL0L1Latency(L0L1Latency), mDeltaBC(deltaBC), mContributingChannels(0)
+Cluster::Cluster(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz, double timeRaw, double time, float tot, int L0L1Latency, int deltaBC) : o2::BaseCluster<float>(sensid, x, y, z, sy2, sz2, syz), mTimeRaw(timeRaw), mTime(time), mTot(tot), mL0L1Latency(L0L1Latency), mDeltaBC(deltaBC), mContributingChannels(0)
 {
 
   // caching R and phi

--- a/Detectors/TOF/base/include/TOFBase/Digit.h
+++ b/Detectors/TOF/base/include/TOFBase/Digit.h
@@ -11,7 +11,6 @@
 #ifndef ALICEO2_TOF_DIGIT_H_
 #define ALICEO2_TOF_DIGIT_H_
 
-#include <CommonDataFormat/TimeStamp.h>
 #include <iosfwd>
 #include "Rtypes.h"
 
@@ -21,12 +20,12 @@ namespace o2 {
 namespace tof {
 /// \class Digit
 /// \brief TOF digit implementation
-class Digit : public o2::dataformats::TimeStamp<double>
+class Digit
 {
  public:
   Digit() = default;
 
-  Digit(Double_t time, Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t label = -1);
+  Digit(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t label = -1);
   ~Digit() = default;
 
   /// Get global ordering key made of
@@ -52,7 +51,7 @@ class Digit : public o2::dataformats::TimeStamp<double>
 
   void printStream(std::ostream &stream) const;
 
-  void merge(Double_t time, Int_t tdc, Int_t tot);
+  void merge(Int_t tdc, Int_t tot);
 
   void getPhiAndEtaIndex(int& phi, int& eta);
 

--- a/Detectors/TOF/base/src/Digit.cxx
+++ b/Detectors/TOF/base/src/Digit.cxx
@@ -17,8 +17,8 @@ using namespace o2::tof;
 
 ClassImp(o2::tof::Digit);
 
-Digit::Digit(Double_t time, Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t label)
-  : o2::dataformats::TimeStamp<double>(time), mChannel(channel), mTDC(tdc), mTOT(tot), mBC(bc), mLabel(label), mIsUsedInCluster(kFALSE)
+Digit::Digit(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t label)
+  : mChannel(channel), mTDC(tdc), mTOT(tot), mBC(bc), mLabel(label), mIsUsedInCluster(kFALSE)
 {
 }
 
@@ -26,8 +26,7 @@ Digit::Digit(Double_t time, Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t
 
 void Digit::printStream(std::ostream& stream) const
 {
-  stream << "TOF Digit: Channel " << mChannel << " TDC " << mTDC << " TOT " << mTOT << " Time " << getTimeStamp()
-         << "Bunch Crossing index" << mBC << " Label " << mLabel << "\n";
+  stream << "TOF Digit: Channel " << mChannel << " TDC " << mTDC << " TOT " << mTOT << "Bunch Crossing index" << mBC << " Label " << mLabel << "\n";
 }
 
 //______________________________________________________________________
@@ -40,14 +39,13 @@ std::ostream& operator<<(std::ostream& stream, const Digit& digi)
 
 //______________________________________________________________________
 
-void Digit::merge(Double_t time, Int_t tdc, Int_t tot)
+void Digit::merge(Int_t tdc, Int_t tot)
 {
 
   // merging two digits
 
   if (tdc < mTDC) {
     mTDC = tdc;
-    setTimeStamp(time);
     // TODO: adjust TOT
   } else {
     // TODO: adjust TOT

--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -131,7 +131,8 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
   }
 
   c.setMainContributingChannel(mContributingDigit[0]->getChannel());
-  c.setTime(mContributingDigit[0]->getTDC() * Geo::TDCBIN);       // time in ps (for now we assume it calibrated)
+  c.setTime(mContributingDigit[0]->getTDC() * Geo::TDCBIN + double(mContributingDigit[0]->getBC()*25000.));       // time in ps (for now we assume it calibrated)
+
   c.setTot(mContributingDigit[0]->getTOT() * Geo::TOTBIN * 1E-3); // TOT in ns (for now we assume it calibrated)
   //setL0L1Latency(); // to be filled (maybe)
   //setDeltaBC(); // to be filled (maybe)

--- a/Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h
@@ -22,6 +22,18 @@ namespace o2
 {
 namespace tof
 {
+
+class DigitOutput
+{
+ public:
+  std::vector< std::vector<Digit> > *get() {return &mVector;}
+
+ private:
+  std::vector< std::vector<Digit> > mVector;
+
+  ClassDefNV(DigitOutput, 1);
+};
+
 class Digitizer
 {
  public:
@@ -66,8 +78,8 @@ class Digitizer
   void setContinuous(bool val) { mContinuous = val; }
   bool isContinuous() const { return mContinuous; }
 
-  const std::vector< std::vector<Digit> >* getDigitPerTimeFrame() const {return &mDigitsPerTimeFrame;}
-  const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel> >* getMCTruthPerTimeFrame() const {return &mMCTruthOutputContainerPerTimeFrame;}
+  DigitOutput* getDigitPerTimeFrame() {return &mDigitsPerTimeFrame;}
+  std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel> >* getMCTruthPerTimeFrame() {return &mMCTruthOutputContainerPerTimeFrame;}
 
  private:
   // parameters
@@ -101,7 +113,7 @@ class Digitizer
 
   static const int MAXWINDOWS = 2; // how many readout windows we can buffer
 
-  std::vector< std::vector<Digit> > mDigitsPerTimeFrame;
+  DigitOutput mDigitsPerTimeFrame;
   std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel> > mMCTruthOutputContainerPerTimeFrame;
 
   int mIcurrentReadoutWindow = 0;
@@ -123,7 +135,7 @@ class Digitizer
 
   o2::dataformats::MCTruthContainer<o2::tof::MCLabel> mFutureMCTruthContainer;
 
-  void fillDigitsInStrip(std::vector<Strip>* strips, o2::dataformats::MCTruthContainer<o2::tof::MCLabel>* mcTruthContainer, double time, int channel, int tdc, int tot, int nbc, UInt_t istrip, Int_t trackID, Int_t eventID, Int_t sourceID);
+  void fillDigitsInStrip(std::vector<Strip>* strips, o2::dataformats::MCTruthContainer<o2::tof::MCLabel>* mcTruthContainer, int channel, int tdc, int tot, int nbc, UInt_t istrip, Int_t trackID, Int_t eventID, Int_t sourceID);
 
   Int_t processHit(const HitType& hit, Double_t event_time);
   void addDigit(Int_t channel, UInt_t istrip, Float_t time, Float_t x, Float_t z, Float_t charge, Int_t iX, Int_t iZ, Int_t padZfired,

--- a/Detectors/TOF/simulation/include/TOFSimulation/Strip.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Strip.h
@@ -93,7 +93,7 @@ class Strip
   /// @return Hit at given index (nullptr if index is out of bounds)
   inline const o2::tof::HitType* getHitAt(Int_t index) const { return mHits.at(index); }
 
-  Int_t addDigit(Double_t time, Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t lbl); // returns the MC label
+  Int_t addDigit(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t lbl); // returns the MC label
 
   void fillOutputContainer(std::vector<o2::tof::Digit>& digits);
 

--- a/Detectors/TOF/simulation/src/Strip.cxx
+++ b/Detectors/TOF/simulation/src/Strip.cxx
@@ -56,7 +56,7 @@ Int_t Strip::getStripIndex(const HitType* hit)
   return channelID / Geo::NPADS;
 }
 //_______________________________________________________________________
-Int_t Strip::addDigit(Double_t time, Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t lbl)
+Int_t Strip::addDigit(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t lbl)
 {
 
   // return the MC label. We pass it also as argument, but it can change in
@@ -66,9 +66,9 @@ Int_t Strip::addDigit(Double_t time, Int_t channel, Int_t tdc, Int_t tot, Int_t 
   auto dig = findDigit(key);
   if (dig) {
     lbl = dig->getLabel();      // getting the label from the already existing digit
-    dig->merge(time, tdc, tot); // merging to the existing digit
+    dig->merge(tdc, tot); // merging to the existing digit
   } else {
-    auto digIter = mDigits.emplace(std::make_pair(key, Digit(time, channel, tdc, tot, bc, lbl)));
+    auto digIter = mDigits.emplace(std::make_pair(key, Digit(channel, tdc, tot, bc, lbl)));
   }
 
   return lbl;

--- a/Detectors/TOF/simulation/src/TOFSimulationLinkDef.h
+++ b/Detectors/TOF/simulation/src/TOFSimulationLinkDef.h
@@ -15,6 +15,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::tof::Detector+;
+#pragma link C++ class o2::tof::DigitOutput+;
 #pragma link C++ class o2::tof::Digitizer+;
 #pragma link C++ class o2::tof::DigitizerTask+;
 #pragma link C++ class o2::tof::Strip + ;

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
@@ -131,15 +131,17 @@ DataProcessorSpec getTOFDigitizerSpec(int channel)
 
     // temporary accumulate vector of vecotors of digits in a single vector
     // to be replace once we will be able to write the vector of vectors as different TTree entries
-    const std::vector< std::vector<Digit> >* digitsVectOfVect =  digitizer->getDigitPerTimeFrame();
-    const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel> >* mcLabVecOfVec = digitizer->getMCTruthPerTimeFrame();
-    for(Int_t i=0; i < digitsVectOfVect->size();i++){
-      std::copy(digitsVectOfVect->at(i).begin(), digitsVectOfVect->at(i).end(), std::back_inserter(*digitsAccum.get()));
+    DigitOutput* digitsVectOfVect =  digitizer->getDigitPerTimeFrame();
+    std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel> >* mcLabVecOfVec = digitizer->getMCTruthPerTimeFrame();
+    for(Int_t i=0; i < digitsVectOfVect->get()->size();i++){
+      std::copy(digitsVectOfVect->get()->at(i).begin(), digitsVectOfVect->get()->at(i).end(), std::back_inserter(*digitsAccum.get()));
       labelAccum.mergeAtBack(mcLabVecOfVec->at(i));
     }
 
     LOG(INFO) << "Have " << labelAccum.getNElements() << " TOF labels ";
     // here we have all digits and we can send them to consumer (aka snapshot it onto output)
+    //pc.outputs().snapshot(Output{ "TOF", "DIGITS", 0, Lifetime::Timeframe }, *digitsVectOfVect);
+    // pc.outputs().snapshot(Output{ "TOF", "DIGITSMCTR", 0, Lifetime::Timeframe }, labelAccum);
     pc.outputs().snapshot(Output{ "TOF", "DIGITS", 0, Lifetime::Timeframe }, *digitsAccum.get());
     pc.outputs().snapshot(Output{ "TOF", "DIGITSMCTR", 0, Lifetime::Timeframe }, labelAccum);
     LOG(INFO) << "TOF: Sending ROMode= " << roMode << " to GRPUpdater";


### PR DESCRIPTION
- tof digits no longer inherit fro mtimestamp
- absolute time now written in tof clusters
- DigitOutput structure (vector of vectors) created