### PR TITLE
small fixes

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
@@ -15,6 +15,7 @@
 #define ALICEO2_CALIBTIMESLEWINGPARAMTOF_H
 
 #include <vector>
+#include <array>
 #include "Rtypes.h"
 
 namespace o2
@@ -30,9 +31,9 @@ class CalibTimeSlewingParamTOF
 
   CalibTimeSlewingParamTOF();
 
-  CalibTimeSlewingParamTOF(const CalibTimeSlewingParamTOF& source);
+  CalibTimeSlewingParamTOF(const CalibTimeSlewingParamTOF& source) = default;
 
-  CalibTimeSlewingParamTOF& operator=(const CalibTimeSlewingParamTOF& source);
+  CalibTimeSlewingParamTOF& operator=(const CalibTimeSlewingParamTOF& source) = default;
 
   float getChannelOffset(int channel) const;
 
@@ -79,10 +80,10 @@ class CalibTimeSlewingParamTOF
 
  private:
   // TOF channel calibrations
-  int mChannelStart[NSECTORS][NCHANNELXSECTOR];           ///< array with the index of the first element of a channel in the time slewing vector (per sector)
-  std::vector<std::pair<unsigned short, short>> mTimeSlewing[18]; ///< array of sector vectors; first element of the pair is TOT (in ps), second is t-texp_pi (in ps)
-  float mFractionUnderPeak[NSECTORS][NCHANNELXSECTOR]; ///< array with the fraction of entries below the peak
-  float mSigmaPeak[NSECTORS][NCHANNELXSECTOR];         ///< array with the sigma of the peak
+  std::array<std::array<int, NCHANNELXSECTOR>, NSECTORS> mChannelStart;             ///< array with the index of the first element of a channel in the time slewing vector (per sector)
+  std::array<std::vector<std::pair<unsigned short, short>>, NSECTORS> mTimeSlewing; ///< array of sector vectors; first element of the pair is TOT (in ps), second is t-texp_pi (in ps)
+  std::array<std::array<float, NCHANNELXSECTOR>, NSECTORS> mFractionUnderPeak;      ///< array with the fraction of entries below the peak
+  std::array<std::array<float, NCHANNELXSECTOR>, NSECTORS> mSigmaPeak;              ///< array with the sigma of the peak
 
   ClassDefNV(CalibTimeSlewingParamTOF, 1); // class for TOF time slewing params
 };

--- a/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
+++ b/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
@@ -156,24 +156,3 @@ CalibTimeSlewingParamTOF& CalibTimeSlewingParamTOF::operator+=(const CalibTimeSl
   return *this;
 }
 
-/*
-CalibTimeSlewingParamTOF& CalibTimeSlewingParamTOF::operator+=(const CalibTimeSlewingParamTOF& other)
-{
-  for (int i = 0; i < NSECTORS; i++) {
-    if (other.mTimeSlewing[i].size() > mTimeSlewing[i].size()) {
-
-      mTimeSlewing[i].clear();
-      for (auto obj = other.mTimeSlewing[i].begin(); obj != other.mTimeSlewing[i].end(); obj++)
-        mTimeSlewing[i].push_back(*obj);
-
-      for (int j = 0; j < NCHANNELXSECTOR; j++) {
-        mChannelStart[i][j] = other.mChannelStart[i][j];
-        mFractionUnderPeak[i][j] = other.mFractionUnderPeak[i][j];
-        mSigmaPeak[i][j] = other.mSigmaPeak[i][j];
-      }
-    }
-  }
-  return *this;
-}
-*/
-//______________________________________________

--- a/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
+++ b/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
@@ -17,40 +17,16 @@
 
 using namespace o2::dataformats;
 
-//ClassImp(o2::dataformats::CalibTimeSlewingParamTOF);
-
 CalibTimeSlewingParamTOF::CalibTimeSlewingParamTOF()
 {
-  for (int i = 0; i < NSECTORS; i++) {
-    memset(mChannelStart[i], -1, sizeof(mChannelStart[i]));
-    memset(mFractionUnderPeak[i], -100, sizeof(mFractionUnderPeak[i]));
-    memset(mSigmaPeak[i], -1., sizeof(mSigmaPeak[i]));
-  }
-}
-//______________________________________________
-CalibTimeSlewingParamTOF::CalibTimeSlewingParamTOF(const CalibTimeSlewingParamTOF& source)
-{
 
-  for (int iSec = 0; iSec < NSECTORS; iSec++) {
-    mTimeSlewing[iSec] = source.mTimeSlewing[iSec];
-  }
   for (int i = 0; i < NSECTORS; i++) {
-    memcpy(mChannelStart[i], source.mChannelStart[i], sizeof(mChannelStart[i]));
-    memcpy(mFractionUnderPeak[i], source.mFractionUnderPeak[i], sizeof(mFractionUnderPeak[i]));
-    memcpy(mSigmaPeak[i], source.mSigmaPeak[i], sizeof(mSigmaPeak[i]));
+    memset(mChannelStart[i].data(), -1, sizeof(mChannelStart[i]));
+    for (int j = 0; j < NCHANNELXSECTOR; j++) {
+      mFractionUnderPeak[i][j] = -100.;
+      mSigmaPeak[i][j] = -1.;
+    }
   }
-}
-//______________________________________________
-CalibTimeSlewingParamTOF& CalibTimeSlewingParamTOF::operator=(const CalibTimeSlewingParamTOF& source)
-{
-  for (int i = 0; i < NSECTORS; i++) {
-    mTimeSlewing[i].clear(); // CHECK: mTimeSlewing[i] does not work, probably because it is an array of vectors
-    mTimeSlewing[i] = source.mTimeSlewing[i];
-    memcpy(mChannelStart[i], source.mChannelStart[i], sizeof(mChannelStart[i]));
-    memcpy(mFractionUnderPeak[i], source.mFractionUnderPeak[i], sizeof(mFractionUnderPeak[i]));
-    memcpy(mSigmaPeak[i], source.mSigmaPeak[i], sizeof(mSigmaPeak[i]));
-  }
-  return *this;
 }
 
 //______________________________________________
@@ -90,8 +66,9 @@ float CalibTimeSlewingParamTOF::evalTimeSlewing(int channel, float totIn) const
   // we convert tot from ns to ps and to unsigned short
   unsigned short tot = (unsigned short)(totIn * 1000);
 
-  while (n < nstop && tot > (mTimeSlewing[sector])[n].first)
+  while (n < nstop && tot > (mTimeSlewing[sector])[n].first) {
     n++;
+  }
   n--;
 
   if (n < 0) { // tot is lower than the first available value
@@ -166,7 +143,20 @@ bool CalibTimeSlewingParamTOF::updateOffsetInfo(int channel, float residualOffse
   return true;
 }
 //______________________________________________
+CalibTimeSlewingParamTOF& CalibTimeSlewingParamTOF::operator+=(const CalibTimeSlewingParamTOF& other)
+{
+  for (int i = 0; i < NSECTORS; i++) {
+    if (other.mTimeSlewing[i].size() > mTimeSlewing[i].size()) {
+      mTimeSlewing[i] = other.mTimeSlewing[i];
+      mChannelStart[i] = other.mChannelStart[i];
+      mFractionUnderPeak[i] = other.mFractionUnderPeak[i];
+      mSigmaPeak[i] = other.mSigmaPeak[i];
+    }
+  }
+  return *this;
+}
 
+/*
 CalibTimeSlewingParamTOF& CalibTimeSlewingParamTOF::operator+=(const CalibTimeSlewingParamTOF& other)
 {
   for (int i = 0; i < NSECTORS; i++) {
@@ -185,4 +175,5 @@ CalibTimeSlewingParamTOF& CalibTimeSlewingParamTOF::operator+=(const CalibTimeSl
   }
   return *this;
 }
+*/
 //______________________________________________


### PR DESCRIPTION
Hi Chiara,

Since I put a misleading comment in my review, I open here PR fixing consequences of my wrong advice. I also added some simplifications (std::arrays instead of C arrays, in this way the default copy constructor and operator= will be viable).

Additionally: I am not sure in your ``CalibTimeSlewingParamTOF::operator+=``, in your original version you are copying (not adding) the data of the ``other`` particular sector if its ``mTimeSlewing`` vector is larger than that of ``this``. And the copy was done in a inefficient way. I've commented your version and added more efficient code doing exactly the same. But please check if your method was doing what you want it to do.

Last comment: if you decide that ``mFractionUnderPeak`` and ``mSigmaPeak`` can use 0 as default value (will require a couple of changes in the TOF/calibration code), just substitute my lines 25-27 by
````
memset(mFractionUnderPeak[i].data(),0,sizeof(mFractionUnderPeak[i]));
memset(mSigmaPeak[i].data(),0,sizeof(mSigmaPeak[i]));
````

Could you also squash the fixups in the end?
