### PR TITLE
Modify detector calib.code to match to new CCDB populator inputs

### DIFF
--- a/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVBadMapCalibDevice.cxx
+++ b/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVBadMapCalibDevice.cxx
@@ -149,7 +149,6 @@ void CPVBadMapCalibDevice::sendOutput(DataAllocator& output)
 {
   // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
   // TODO in principle, this routine is generic, can be moved to Utils.h
-  // using clbUtils = o2::calibration::Utils;
 
   if (mUpdateCCDB || mForceUpdate) {
     // prepare all info to be sent to CCDB
@@ -170,8 +169,8 @@ void CPVBadMapCalibDevice::sendOutput(DataAllocator& output)
     LOG(INFO) << "Sending object CPV/Calib/BadChannelMap";
 
     header::DataHeader::SubSpecificationType subSpec{(header::DataHeader::SubSpecificationType)0};
-    output.snapshot(Output{o2::calibration::Utils::gDataOriginCLB, o2::calibration::Utils::gDataDescriptionCLBPayload, subSpec}, *image.get());
-    output.snapshot(Output{o2::calibration::Utils::gDataOriginCLB, o2::calibration::Utils::gDataDescriptionCLBInfo, subSpec}, info);
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_BadChanMap", subSpec}, *image.get());
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_BadChanMap", subSpec}, info);
   }
 
   output.snapshot(o2::framework::Output{"CPV", "BADMAPCHANGE", 0, o2::framework::Lifetime::Timeframe}, mMapDiff);
@@ -206,7 +205,9 @@ o2::framework::DataProcessorSpec o2::cpv::getBadMapCalibSpec(bool useCCDB, bool 
 {
 
   std::vector<o2::framework::OutputSpec> outputs;
-  outputs.emplace_back("CPV", "BADMAP", 0, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_BadChanMap"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_BadChanMap"});
+
   outputs.emplace_back("CPV", "BADMAPCHANGE", 0, o2::framework::Lifetime::Timeframe);
 
   return o2::framework::DataProcessorSpec{"BadMapCalibSpec",

--- a/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVGainCalibDevice.cxx
+++ b/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVGainCalibDevice.cxx
@@ -101,7 +101,7 @@ void CPVGainCalibDevice::sendOutput(DataAllocator& output)
 {
   // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
   // TODO in principle, this routine is generic, can be moved to Utils.h
-  // using clbUtils = o2::calibration::Utils;
+
   if (mUpdateCCDB || mForceUpdate) {
     // prepare all info to be sent to CCDB
     o2::ccdb::CcdbObjectInfo info;
@@ -121,8 +121,9 @@ void CPVGainCalibDevice::sendOutput(DataAllocator& output)
     LOG(INFO) << "Sending object CPV/Calib/CalibParams";
 
     header::DataHeader::SubSpecificationType subSpec{(header::DataHeader::SubSpecificationType)0};
-    output.snapshot(Output{o2::calibration::Utils::gDataOriginCLB, o2::calibration::Utils::gDataDescriptionCLBPayload, subSpec}, *image.get());
-    output.snapshot(Output{o2::calibration::Utils::gDataOriginCLB, o2::calibration::Utils::gDataDescriptionCLBInfo, subSpec}, info);
+
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_CalibParams", subSpec}, *image.get());
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_CalibParams", subSpec}, info);
   }
 
   //Write either final spectra (to calculate bad map) or temporary file
@@ -214,7 +215,9 @@ o2::framework::DataProcessorSpec o2::cpv::getGainCalibSpec(bool useCCDB, bool fo
 {
 
   std::vector<o2::framework::OutputSpec> outputs;
-  outputs.emplace_back("CPV", "GAINCALIBS", 0, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_CalibParams"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_CalibParams"});
+
   outputs.emplace_back("CPV", "GAINDIFF", 0, o2::framework::Lifetime::Timeframe);
 
   return o2::framework::DataProcessorSpec{"GainCalibSpec",

--- a/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVPedestalCalibDevice.cxx
+++ b/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVPedestalCalibDevice.cxx
@@ -114,8 +114,8 @@ void CPVPedestalCalibDevice::sendOutput(DataAllocator& output)
     LOG(INFO) << "Sending object CPV/Calib/Pedestals";
 
     header::DataHeader::SubSpecificationType subSpec{(header::DataHeader::SubSpecificationType)0};
-    output.snapshot(Output{o2::calibration::Utils::gDataOriginCLB, o2::calibration::Utils::gDataDescriptionCLBPayload, subSpec}, *image.get());
-    output.snapshot(Output{o2::calibration::Utils::gDataOriginCLB, o2::calibration::Utils::gDataDescriptionCLBInfo, subSpec}, info);
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_PEDESTALS", subSpec}, *image.get());
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_PEDESTALS", subSpec}, info);
   }
   //Anyway send change to QC
   LOG(INFO) << "[CPVPedestalCalibDevice - run] Writing ";
@@ -172,7 +172,9 @@ o2::framework::DataProcessorSpec o2::cpv::getPedestalCalibSpec(bool useCCDB, boo
 {
 
   std::vector<o2::framework::OutputSpec> outputs;
-  outputs.emplace_back("CPV", "PEDCALIBS", 0, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_PEDESTALS"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_PEDESTALS"});
+
   outputs.emplace_back("CPV", "PEDDIFF", 0, o2::framework::Lifetime::Timeframe);
 
   return o2::framework::DataProcessorSpec{"PedestalCalibSpec",

--- a/Detectors/Calibration/README.md
+++ b/Detectors/Calibration/README.md
@@ -56,8 +56,8 @@ information (metadata, startValidity...) associated to the objects themselves.
 E.g.:
 
 ```c++
-output.snapshot(Output{clbUtils::gDataOriginCLB, o2::calibration::Utils::gDataDescriptionCLBPayload, i}, *image.get()); // vector<char>
-output.snapshot(Output{clbUtils::gDataOriginCLB, o2::calibration::Utils::gDataDescriptionCLBInfo, i}, w);               // root-serialized
+output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_LHCphase", i}, *image.get()); // vector<char>
+output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_LHCphase", i}, w);            // root-serialized
 ```
 The origin of the output will always be `o2::calibration::Utils::gDataOriginCLB`, while the description will be `clbUtils::gDataDescriptionCLBPayload` for the object itself, and `o2::calibration::Utils::gDataDescriptionCLBInfo` for the description.
 

--- a/Detectors/Calibration/include/DetectorsCalibration/Utils.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/Utils.h
@@ -28,7 +28,6 @@ namespace calibration
 {
 
 struct Utils {
-
   static constexpr o2::header::DataOrigin gDataOriginCLB{"CLB"};                          // generic DataOrigin for calibrations
   static constexpr o2::header::DataDescription gDataDescriptionCLBPayload = "CLBPAYLOAD"; // DataDescription for TMemFile sent for CCDB storage
   static constexpr o2::header::DataDescription gDataDescriptionCLBInfo = "CCDBWRAPPER";   // DataDescription for wrapper helper

--- a/Detectors/Calibration/workflow/src/MeanVertexCalibratorSpec.cxx
+++ b/Detectors/Calibration/workflow/src/MeanVertexCalibratorSpec.cxx
@@ -88,8 +88,9 @@ void MeanVertexCalibDevice::sendOutput(DataAllocator& output)
     auto image = o2::ccdb::CcdbApi::createObjectImage(&payloadVec[i], &w);
     LOG(INFO) << "Sending object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
               << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
-    output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, i}, *image.get()); // vector<char>
-    output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, i}, w);               // root-serialized
+
+    output.snapshot(Output{clbUtils::gDataOriginCDBPayload, "MEANVERTEX", i}, *image.get()); // vector<char>
+    output.snapshot(Output{clbUtils::gDataOriginCDBWrapper, "MEANVERTEX", i}, w);            // root-serialized
   }
   if (payloadVec.size()) {
     mCalibrator->initOutput(); // reset the outputs once they are already sent
@@ -107,8 +108,8 @@ DataProcessorSpec getMeanVertexCalibDeviceSpec()
   using clbUtils = o2::calibration::Utils;
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "MEANVERTEX"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "MEANVERTEX"});
 
   return DataProcessorSpec{
     "mean-vertex-calibration",

--- a/Detectors/DCS/testWorkflow/src/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/src/DCSDataProcessorSpec.h
@@ -301,8 +301,9 @@ class DCSDataProcessor : public o2::framework::Task
       LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
                 << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
-      output.snapshot(framework::Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get());
-      output.snapshot(framework::Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info);
+      // every CDB object must be sent with its unique DataDescription/SubSpec
+      output.snapshot(framework::Output{o2::calibration::Utils::gDataOriginCDBPayload, "DCS_TST", idet}, *image.get());
+      output.snapshot(framework::Output{o2::calibration::Utils::gDataOriginCDBWrapper, "DCS_TST", idet}, info);
     }
   }
 }; // end class
@@ -317,8 +318,8 @@ DataProcessorSpec getDCSDataProcessorSpec()
   using clbUtils = o2::calibration::Utils;
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "DCS_TST"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "DCS_TST"});
 
   return DataProcessorSpec{
     "dcs-data-processor",

--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -89,8 +89,8 @@ class EMCALChannelCalibDevice : public o2::framework::Task
       auto image = o2::ccdb::CcdbApi::createObjectImage(&payloadVec[i], &w);
       LOG(INFO) << "Sending object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
                 << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
-      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, i}, *image.get()); // vector<char>
-      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, i}, w);               // root-serialized
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EMC_CHANNEL", i}, *image.get()); // vector<char>
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "EMC_CHANNEL", i}, w);               // root-serialized
     }
     */
     //if (payloadVec.size()) {
@@ -110,8 +110,8 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec()
   using clbUtils = o2::calibration::Utils;
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EMC_CHANNEL"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EMC_CHANNEL"});
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("input", o2::header::gDataOriginEMC, "CELLS");

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
@@ -70,10 +70,8 @@ void NoiseCalibratorSpec::sendOutput(DataAllocator& output)
             << " : " << info.getEndValidityTimestamp();
 
   using clbUtils = o2::calibration::Utils;
-  output.snapshot(
-    Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get());
-  output.snapshot(
-    Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info);
+  output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, 0}, *image.get());
+  output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, 0}, info);
 }
 
 void NoiseCalibratorSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
@@ -90,10 +88,8 @@ DataProcessorSpec getNoiseCalibratorSpec()
 
   using clbUtils = o2::calibration::Utils;
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(
-    ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
-  outputs.emplace_back(
-    ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "ITS_NOISE"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "ITS_NOISE"});
 
   return DataProcessorSpec{
     "its-noise-calibrator",

--- a/Detectors/MUON/MCH/Calibration/src/MCHChannelCalibratorSpec.h
+++ b/Detectors/MUON/MCH/Calibration/src/MCHChannelCalibratorSpec.h
@@ -135,8 +135,8 @@ class MCHChannelCalibDevice : public o2::framework::Task
     auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
     LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
               << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
-    output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get());
-    output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info); // root-serialized
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "MCH_BADCHAN", 0}, *image.get());
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "MCH_BADCHAN", 0}, info); // root-serialized
 
     size_t pedestalsSize;
     char* pedestalsBuffer = createBuffer(mCalibrator->getPedestalsVector(), pedestalsSize);
@@ -160,8 +160,8 @@ DataProcessorSpec getMCHChannelCalibDeviceSpec()
   using clbUtils = o2::calibration::Utils;
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "MCH_BADCHAN"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "MCH_BADCHAN"});
   outputs.emplace_back(OutputSpec{"MCH", "PEDESTALS", 0, Lifetime::Timeframe});
 
   std::vector<InputSpec> inputs;

--- a/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
@@ -101,7 +101,6 @@ DataProcessorSpec getTOFCalibCollectorDeviceSpec()
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(o2::header::gDataOriginTOF, "COLLECTEDINFO", 0, Lifetime::Timeframe);
-  // or should I use the ConcreteDataTypeMatcher? e.g.: outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
   outputs.emplace_back(o2::header::gDataOriginTOF, "ENTRIESCH", 0, Lifetime::Timeframe);
 
   std::vector<InputSpec> inputs;

--- a/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
@@ -162,8 +162,9 @@ class TOFChannelCalibDevice : public o2::framework::Task
       auto image = o2::ccdb::CcdbApi::createObjectImage(&payloadVec[i], &w);
       LOG(INFO) << "Sending object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
                 << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
-      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, i}, *image.get()); // vector<char>
-      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, i}, w);               // root-serialized
+
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_CHANCALIB", i}, *image.get()); // vector<char>
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_CHANCALIB", i}, w);            // root-serialized
     }
     if (payloadVec.size()) {
       mCalibrator->initOutput(); // reset the outputs once they are already sent
@@ -182,8 +183,8 @@ DataProcessorSpec getTOFChannelCalibDeviceSpec(bool useCCDB, bool attachChannelO
   using clbUtils = o2::calibration::Utils;
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_CHANCALIB"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_CHANCALIB"});
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("input", "TOF", "CALIBDATA");

--- a/Detectors/TOF/calibration/testWorkflow/TOFDCSDataProcessorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFDCSDataProcessorSpec.h
@@ -139,8 +139,8 @@ class TOFDCSDataProcessor : public o2::framework::Task
     auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
     LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
               << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
-    output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get());
-    output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info);
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_DCSDPs", 0}, *image.get());
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_DCSDPs", 0}, info);
     mProcessor->clearDPsinfo();
   }
 
@@ -155,8 +155,9 @@ class TOFDCSDataProcessor : public o2::framework::Task
       auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
       LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
                 << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
-      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get());
-      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info);
+
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_LVStatus", 0}, *image.get());
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_LVStatus", 0}, info);
     }
     if (mProcessor->isHVUpdated()) {
       const auto& payload = mProcessor->getHVStatus();
@@ -164,8 +165,8 @@ class TOFDCSDataProcessor : public o2::framework::Task
       auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
       LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
                 << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
-      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get());
-      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info);
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_HVStatus", 0}, *image.get());
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_HVStatus", 0}, info);
     }
   }
 
@@ -181,8 +182,14 @@ DataProcessorSpec getTOFDCSDataProcessorSpec()
   using clbUtils = o2::calibration::Utils;
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
-  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_LVStatus"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_LVStatus"});
+
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_HVStatus"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_HVStatus"});
+
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_DCSDPs"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_DCSDPs"});
 
   return DataProcessorSpec{
     "tof-dcs-data-processor",


### PR DESCRIPTION
Hi @chiarazampolli 

Here is it. What is not covered by this PR:
````
Detectors/PHOS/calib/PHOSCalibWorkflow/src/PHOSHGLGRatioCalibDevice.cxx
Detectors/PHOS/calib/PHOSCalibWorkflow/src/PHOSPedestalCalibDevice.cxx
````
They don't define any output to the ccdb-populator but send it (in the 1st one commented). Not sure if this is not a dead code, one should ask them.

````
Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPedestalSpec.h
Detectors/TPC/workflow/src/CalDetMergerPublisherSpec.cxx
````
These are connected workflows, one passes to another the gDataOriginCLB/gDataDescriptionCLBPayload messages, this should be changed

Once these points are fixed (I guess we should ask Dmitri and Jens respectively), the old 
````
  static constexpr o2::header::DataOrigin gDataOriginCLB{"CLB"};                          // generic DataOrigin for calibrations
  static constexpr o2::header::DataDescription gDataDescriptionCLBPayload = "CLBPAYLOAD"; // DataDescription for TMemFile sent for CCDB storage
  static constexpr o2::header::DataDescription gDataDescriptionCLBInfo = "CCDBWRAPPER";   // DataDescription for wrapper helper
````
can be removed from the Detectors/Calibration/include/DetectorsCalibration/Utils.h